### PR TITLE
feat: Colab auto-install with --pre for alpha branch

### DIFF
--- a/docs/nobrainer-guides/scripts/01-getting_started.py
+++ b/docs/nobrainer-guides/scripts/01-getting_started.py
@@ -75,7 +75,17 @@
 # Nobrainer can be installed using `pip`.
 
 # %%
-# !uv pip install --pre nobrainer
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %% [markdown]
 # # Accessing Nobrainer

--- a/docs/nobrainer-guides/scripts/02-preparing_training_data.py
+++ b/docs/nobrainer-guides/scripts/02-preparing_training_data.py
@@ -22,7 +22,17 @@
 
 
 # %%
-# !uv pip install --pre nobrainer nilearn
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %%
 import nibabel as nib

--- a/docs/nobrainer-guides/scripts/03-train_brain_extraction.py
+++ b/docs/nobrainer-guides/scripts/03-train_brain_extraction.py
@@ -44,7 +44,17 @@
 # # Install and setup `nobrainer`
 
 # %%
-# !uv pip install --pre nobrainer nilearn
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %%
 import nibabel as nib

--- a/docs/nobrainer-guides/scripts/04-train_brain_generation.py
+++ b/docs/nobrainer-guides/scripts/04-train_brain_generation.py
@@ -25,7 +25,17 @@
 # 5. Generate synthetic brain volumes
 
 # %%
-# !uv pip install --pre nilearn nobrainer
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %%
 import nibabel as nib

--- a/docs/nobrainer-guides/scripts/05-training_with_augmentation.py
+++ b/docs/nobrainer-guides/scripts/05-training_with_augmentation.py
@@ -47,7 +47,17 @@
 # # Install and setup `nobrainer`
 
 # %%
-# !uv pip install --pre nobrainer nilearn
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %%
 import nibabel as nib

--- a/docs/nobrainer-guides/scripts/06-train_with_checkpoints.py
+++ b/docs/nobrainer-guides/scripts/06-train_with_checkpoints.py
@@ -39,7 +39,17 @@
 # # Install and setup `nobrainer`
 
 # %%
-# !uv pip install --pre nobrainer nilearn
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q",
+         "nobrainer", "nilearn", "matplotlib"]
+    )
+except ImportError:
+    pass  # Not on Colab; install manually with: uv pip install nobrainer
 
 # %%
 import os

--- a/docs/nobrainer-guides/scripts/07-synthseg_generation.py
+++ b/docs/nobrainer-guides/scripts/07-synthseg_generation.py
@@ -7,7 +7,16 @@
 # In[9]:
 
 
-# get_ipython().system('uv pip install --pre nobrainer')
+import subprocess
+import sys
+
+try:
+    import google.colab  # noqa: F401
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "--pre", "-q", "nobrainer"]
+    )
+except ImportError:
+    pass  # Not on Colab
 
 
 # In[10]:


### PR DESCRIPTION
## Summary

Each tutorial script now auto-detects Google Colab and installs nobrainer:

```python
try:
    import google.colab
    subprocess.check_call([sys.executable, "-m", "pip", "install", "--pre", "-q",
                           "nobrainer", "nilearn", "matplotlib"])
except ImportError:
    pass  # Not on Colab; install manually with: uv pip install nobrainer
```

- On Colab: auto-installs pre-release nobrainer + deps
- Outside Colab: no-op (user installs manually)
- `--pre` flag ensures alpha releases are picked up

**When merging alpha → master**: remove `"--pre"` from the install args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)